### PR TITLE
Added support for GHC 7.10.1 and Cabal 1.22

### DIFF
--- a/Gtk2HsSetup.hs
+++ b/Gtk2HsSetup.hs
@@ -159,7 +159,12 @@ register pkg@(library       -> Just lib )
   = do
 
     installedPkgInfoRaw <- generateRegistrationInfo
+
+#if CABAL_VERSION_CHECK(1,22,0)
+                           verbosity pkg lib lbi clbi inplace False distPref packageDb
+#else
                            verbosity pkg lib lbi clbi inplace distPref
+#endif
 
     dllsInScope <- getSearchPath >>= (filterM doesDirectoryExist) >>= getDlls
     let libs = fixLibs dllsInScope (extraLibraries installedPkgInfoRaw)

--- a/Media/Streaming/GStreamer/Core/Caps.chs
+++ b/Media/Streaming/GStreamer/Core/Caps.chs
@@ -90,6 +90,7 @@ module Media.Streaming.GStreamer.Core.Caps (
 
 {# context lib = "gstreamer" prefix = "gst" #}
 
+import Control.Applicative
 import Control.Monad (liftM)
 import Control.Monad.Reader
 import System.Glib.FFI

--- a/Media/Streaming/GStreamer/Core/Caps.chs
+++ b/Media/Streaming/GStreamer/Core/Caps.chs
@@ -256,7 +256,7 @@ capsFromString string =
 -- | A 'Monad' for sequencing modifications to a 'Caps'.
 newtype CapsM a =
     CapsM (ReaderT (Ptr Caps) IO a)
-    deriving (Functor, Monad)
+    deriving (Functor, Applicative, Monad)
 
 askCapsPtr :: CapsM (Ptr Caps)
 askCapsPtr = CapsM $ ask

--- a/Media/Streaming/GStreamer/Core/Types.chs
+++ b/Media/Streaming/GStreamer/Core/Types.chs
@@ -156,7 +156,8 @@ module Media.Streaming.GStreamer.Core.Types (
   
   ) where
 
-import Control.Monad       ( liftM )
+import Control.Applicative
+import Control.Monad       ( liftM, ap )
 import Control.Monad.Reader
 import Control.Monad.Trans
 import Data.Ratio          ( Ratio )

--- a/Media/Streaming/GStreamer/Core/Types.chs
+++ b/Media/Streaming/GStreamer/Core/Types.chs
@@ -452,7 +452,7 @@ giveMiniObject obj action =
 newtype (MiniObjectClass miniObjectT, Monad m) =>
     MiniObjectT miniObjectT m a =
         MiniObjectT (ReaderT (Ptr miniObjectT) m a)
-        deriving (Functor, Monad, MonadTrans)
+        deriving (Functor, Applicative, Monad, MonadTrans)
 instance (MiniObjectClass miniObjectT, Monad m, MonadIO m) =>
     MonadIO (MiniObjectT miniObjectT m) where
         liftIO = MiniObjectT . liftIO
@@ -687,6 +687,13 @@ instance Monad StructureM where
                let StructureM bM = fbM a
                bM structure
     return a = StructureM $ const $ return a
+
+instance Applicative StructureM where
+    pure = return
+    (<*>) = ap
+
+instance Functor StructureM where
+    fmap = liftM
 
 --------------------------------------------------------------------
 

--- a/SetupWrapper.hs
+++ b/SetupWrapper.hs
@@ -9,7 +9,7 @@ import Distribution.Simple.Utils
 import Distribution.Simple.Program
 import Distribution.Simple.Compiler
 import Distribution.Simple.BuildPaths (exeExtension)
-import Distribution.Simple.Configure (configCompiler)
+import Distribution.Simple.Configure (configCompilerEx)
 import Distribution.Simple.GHC (getInstalledPackages)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Version
@@ -18,7 +18,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit
+import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception
@@ -115,7 +115,7 @@ setupWrapper setupHsFile = do
       when outOfDate $ do
         debug verbosity "Setup script is out of date, compiling..."
 
-        (comp, conf)    <- configCompiler (Just GHC) Nothing Nothing
+        (comp, _, conf) <- configCompilerEx (Just GHC) Nothing Nothing
                              defaultProgramConfiguration verbosity
         cabalLibVersion <- cabalLibVersionToUse comp conf
         let cabalPkgid = PackageIdentifier (PackageName "Cabal") cabalLibVersion

--- a/gstreamer.cabal
+++ b/gstreamer.cabal
@@ -1,5 +1,5 @@
 Name:           gstreamer
-Version:        0.12.5.0
+Version:        0.12.5.1
 License:        LGPL-2.1
 License-file:   COPYING
 Copyright:      (c) 2001-2010 The Gtk2Hs Team
@@ -54,7 +54,7 @@ Source-Repository head
 Library
         build-depends:  base >= 3 && < 5,
                         directory, array, bytestring, mtl,
-                        glib  >= 0.12.5.0 && < 0.13
+                        glib  >= 0.13 && < 0.14
 
         build-tools:    gtk2hsC2hs >= 0.13.9,
                         gtk2hsTypeGen, gtk2hsHookGenerator


### PR DESCRIPTION
Hello,

as the title suggests, I added support for both GHC 7.10.1 and Cabal 1.22. I looked at the other projects' Gtk2HsSetup.hs and SetupWrapper.hs and applied the same kind of changeshere.

I also had to add derive instances for Applicative and make StructureM an instance of Applicataive.